### PR TITLE
Refactor error handling and add validation support

### DIFF
--- a/src/FluentResult/ResultError.cs
+++ b/src/FluentResult/ResultError.cs
@@ -21,7 +21,7 @@ public record ResultError
     /// <param name="code">The error code.</param>
     /// <param name="description">The error description.</param>
     /// <example>
-    ///     How to implement your domain errors:
+    ///     How to implement your errors in a domain:
     ///     <code>
     ///     public static class DomainErrors
     ///     {
@@ -56,9 +56,14 @@ public record ResultError
     /// <summary>The error description.</summary>
     public string Description { get; }
 
-    public void Deconstruct(out string Code, out string Description)
+    /// <summary>
+    /// Deconstructs the <see cref="ResultError"/> into its code and description.
+    /// </summary>
+    /// <param name="code">The error code.</param>
+    /// <param name="description">The error description.</param>
+    public void Deconstruct(out string code, out string description)
     {
-        Code = this.Code;
-        Description = this.Description;
+        code = Code;
+        description = Description;
     }
 }

--- a/src/FluentResult/ResultValidationError.cs
+++ b/src/FluentResult/ResultValidationError.cs
@@ -1,0 +1,22 @@
+namespace DrifterApps.Seeds.FluentResult;
+
+/// <summary>
+///     Represents a list of validation errors.
+/// </summary>
+public record ResultValidationError : ResultError
+{
+    /// <summary>
+    /// Gets the dictionary of validation errors by property names.
+    /// </summary>
+    public IReadOnlyDictionary<string, string[]> ValidationErrors { get; }
+
+    /// <summary>
+    ///     Represents an list of validation errors.
+    /// </summary>
+    /// <param name="code">The error code.</param>
+    /// <param name="description">The error description.</param>
+    /// <param name="validationErrors">Dictionary of validations error by property names.</param>
+    public ResultValidationError(string code, string description,
+        IReadOnlyDictionary<string, string[]> validationErrors)
+        : base(code, description) => ValidationErrors = validationErrors;
+}


### PR DESCRIPTION
- Refactored the `ResultError` class to include a `Deconstruct` method for easier code deconstruction.
- Added a new `ResultValidationError` class to represent a list of validation errors.
- The `ResultValidationError` class inherits from `ResultError` and includes a dictionary of validation errors by property names.

Closes #5